### PR TITLE
Symfony container entries can reference PHP-DI's entries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # .gitattributes
 tests/ export-ignore
 .travis.yml export-ignore
+demo/ export-ignore
 
 # Auto detect text files and perform LF normalization
 * text=auto

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,22 @@
     },
     "autoload-dev": {
         "psr-0": {
-            "UnitTest\\DI\\Bridge\\Symfony": "tests/",
-            "FunctionalTest\\DI\\Bridge\\Symfony": "tests/"
+            "UnitTest\\DI\\Bridge\\Symfony\\": "tests/",
+            "FunctionalTest\\DI\\Bridge\\Symfony\\": "tests/"
         }
     },
     "require": {
         "php": "~5.5|~7.0",
         "php-di/php-di": "^5.0",
-        "symfony/dependency-injection": "^3.0"
+        "symfony/dependency-injection": "^3.0",
+        "symfony/http-kernel": "^3.0",
+        "symfony/proxy-manager-bridge": "^3.0",
+        "symfony/config": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "^4.8",
+        "symfony/filesystem": "^3.0",
+        "symfony/yaml": "^3.0",
+        "symfony/debug": "^3.0"
     }
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Bridge\Symfony;
+
+use Interop\Container\ContainerInterface;
+use Symfony\Component\Debug\DebugClassLoader;
+use Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Customization of Symfony's kernel to setup PHP-DI.
+ *
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+abstract class Kernel extends \Symfony\Component\HttpKernel\Kernel
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $phpdiContainer;
+
+    public function __construct($environment, $debug)
+    {
+        parent::__construct($environment, $debug);
+        $this->disableDebugClassLoader();
+    }
+
+    /**
+     * @return ContainerInterface
+     */
+    abstract protected function buildPHPDIContainer(\DI\ContainerBuilder $builder);
+
+    protected function getContainerBaseClass()
+    {
+        return 'DI\Bridge\Symfony\SymfonyContainerBridge';
+    }
+
+    protected function buildContainer()
+    {
+        $containerBuilder = parent::buildContainer();
+
+        $this->removeInvalidReferenceBehaviorPass($containerBuilder);
+
+        return $containerBuilder;
+    }
+
+    protected function initializeContainer()
+    {
+        parent::initializeContainer();
+
+        /** @var SymfonyContainerBridge $rootContainer */
+        $rootContainer = $this->getContainer();
+
+        $rootContainer->setFallbackContainer($this->getPHPDIContainer());
+    }
+
+    /**
+     * Remove the CheckExceptionOnInvalidReferenceBehaviorPass because
+     * it was not looking into PHP-DI's entries and thus throwing exceptions.
+     *
+     * @todo Replace it by an alternative that can search into PHP-DI too
+     *       Problem: PHP-DI is not initialized when Symfony's container is compiled, because
+     *       it depends on Symfony's container for fallback (cycle…)
+     *
+     * @param ContainerBuilder $container
+     */
+    private function removeInvalidReferenceBehaviorPass(ContainerBuilder $container)
+    {
+        $passConfig = $container->getCompilerPassConfig();
+        $compilationPasses = $passConfig->getRemovingPasses();
+
+        foreach ($compilationPasses as $i => $pass) {
+            if ($pass instanceof CheckExceptionOnInvalidReferenceBehaviorPass) {
+                unset($compilationPasses[$i]);
+                break;
+            }
+        }
+
+        $passConfig->setRemovingPasses($compilationPasses);
+    }
+
+    private function disableDebugClassLoader()
+    {
+        if (!class_exists('Symfony\Component\Debug\DebugClassLoader')) {
+            return;
+        }
+
+        DebugClassLoader::disable();
+    }
+
+    /**
+     * @return ContainerInterface
+     */
+    private function getPHPDIContainer()
+    {
+        if ($this->phpdiContainer === null) {
+            $builder = new \DI\ContainerBuilder();
+            $builder->wrapContainer($this->getContainer());
+
+            $this->phpdiContainer = $this->buildPHPDIContainer($builder);
+        }
+
+        return $this->phpdiContainer;
+    }
+}

--- a/src/SymfonyContainerBridge.php
+++ b/src/SymfonyContainerBridge.php
@@ -10,11 +10,11 @@
 namespace DI\Bridge\Symfony;
 
 use DI\NotFoundException;
+use Interop\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Container as SymfonyContainer;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
-use Interop\Container\ContainerInterface;
 
 /**
  * Replacement for the Symfony service container.

--- a/tests/FunctionalTest/DI/Bridge/Symfony/AbstractFunctionalTest.php
+++ b/tests/FunctionalTest/DI/Bridge/Symfony/AbstractFunctionalTest.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace FunctionalTest\DI\Bridge\Symfony;
+
+use FunctionalTest\DI\Bridge\Symfony\Fixtures\AppKernel;
+use Symfony\Component\Filesystem\Filesystem;
+
+abstract class AbstractFunctionalTest extends \PHPUnit_Framework_TestCase
+{
+    protected function createKernel($configFile = 'empty.yml')
+    {
+        // Clear the cache
+        $fs = new Filesystem();
+        $fs->remove(__DIR__ . '/Fixtures/cache/dev');
+
+        $kernel = new AppKernel($configFile);
+        $kernel->boot();
+
+        return $kernel;
+    }
+}

--- a/tests/FunctionalTest/DI/Bridge/Symfony/ContainerAwareTest.php
+++ b/tests/FunctionalTest/DI/Bridge/Symfony/ContainerAwareTest.php
@@ -9,25 +9,24 @@
 
 namespace FunctionalTest\DI\Bridge\Symfony;
 
-use DI\Bridge\Symfony\SymfonyContainerBridge;
-use DI\ContainerBuilder;
 use FunctionalTest\DI\Bridge\Symfony\Fixtures\ContainerAwareController;
 
-class ContainerAwareInterfaceTest extends \PHPUnit_Framework_TestCase
+/**
+ * @coversNothing
+ */
+class ContainerAwareInterfaceTest extends AbstractFunctionalTest
 {
     /**
      * @link https://github.com/PHP-DI/Symfony2-Bridge/issues/2
      */
     public function testContainerAware()
     {
-        $wrapper = new SymfonyContainerBridge();
-        $builder = new ContainerBuilder();
-        $builder->wrapContainer($wrapper);
-        $wrapper->setFallbackContainer($builder->build());
+        $kernel = $this->createKernel();
+        $container = $kernel->getContainer();
 
         /** @var ContainerAwareController $class */
-        $class = $wrapper->get('FunctionalTest\DI\Bridge\Symfony\Fixtures\ContainerAwareController');
+        $class = $container->get('FunctionalTest\DI\Bridge\Symfony\Fixtures\ContainerAwareController');
 
-        $this->assertSame($wrapper, $class->container);
+        $this->assertSame($container, $class->container);
     }
 }

--- a/tests/FunctionalTest/DI/Bridge/Symfony/Fixtures/.gitignore
+++ b/tests/FunctionalTest/DI/Bridge/Symfony/Fixtures/.gitignore
@@ -1,0 +1,2 @@
+logs
+cache

--- a/tests/FunctionalTest/DI/Bridge/Symfony/Fixtures/AppKernel.php
+++ b/tests/FunctionalTest/DI/Bridge/Symfony/Fixtures/AppKernel.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace FunctionalTest\DI\Bridge\Symfony\Fixtures;
+
+use DI\Bridge\Symfony\Kernel;
+use DI\ContainerBuilder;
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+class AppKernel extends Kernel
+{
+    private $configFile;
+
+    public function __construct($configFile)
+    {
+        $this->configFile = $configFile;
+
+        parent::__construct('dev', true);
+    }
+
+    protected function buildPHPDIContainer(ContainerBuilder $builder)
+    {
+        return $builder->build();
+    }
+
+    public function registerBundles()
+    {
+        return array();
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(__DIR__ . '/config/' . $this->configFile);
+    }
+
+    protected function getContainerClass()
+    {
+        return $this->randomName();
+    }
+
+    private function randomName() {
+        $characters = 'abcdefghijklmnopqrstuvwxyz';
+        $str = '';
+        for ($i = 0; $i < 10; $i++) {
+            $str .= $characters[rand(0, strlen($characters) - 1)];
+        }
+        return $str;
+    }
+}

--- a/tests/FunctionalTest/DI/Bridge/Symfony/Fixtures/config/class1.yml
+++ b/tests/FunctionalTest/DI/Bridge/Symfony/Fixtures/config/class1.yml
@@ -1,0 +1,4 @@
+services:
+    class1:
+        class: FunctionalTest\DI\Bridge\Symfony\Fixtures\Class1
+        arguments: [ '@FunctionalTest\\DI\\Bridge\\Symfony\\Fixtures\\Class2' ]

--- a/tests/FunctionalTest/DI/Bridge/Symfony/Fixtures/config/class2.yml
+++ b/tests/FunctionalTest/DI/Bridge/Symfony/Fixtures/config/class2.yml
@@ -1,0 +1,3 @@
+services:
+    class2:
+        class: FunctionalTest\DI\Bridge\Symfony\Fixtures\Class2

--- a/tests/FunctionalTest/DI/Bridge/Symfony/KernelTest.php
+++ b/tests/FunctionalTest/DI/Bridge/Symfony/KernelTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace FunctionalTest\DI\Bridge\Symfony;
+
+use DI\Bridge\Symfony\SymfonyContainerBridge;
+use FunctionalTest\DI\Bridge\Symfony\Fixtures\Class1;
+use FunctionalTest\DI\Bridge\Symfony\Fixtures\Class2;
+
+/**
+ * @coversNothing
+ */
+class KernelTest extends AbstractFunctionalTest
+{
+    /**
+     * @test
+     */
+    public function kernel_should_boot()
+    {
+        $kernel = $this->createKernel();
+
+        $this->assertTrue($kernel->getContainer() instanceof SymfonyContainerBridge);
+    }
+
+    /**
+     * @test
+     */
+    public function phpdi_should_resolve_classes()
+    {
+        $kernel = $this->createKernel();
+
+        $object = $kernel->getContainer()->get('FunctionalTest\DI\Bridge\Symfony\Fixtures\Class1');
+        $this->assertTrue($object instanceof Class1);
+    }
+
+    /**
+     * @test
+     */
+    public function symfony_should_resolve_classes()
+    {
+        $kernel = $this->createKernel('class2.yml');
+
+        $object = $kernel->getContainer()->get('class2');
+        $this->assertTrue($object instanceof Class2);
+    }
+}


### PR DESCRIPTION
Symfony entires can reference PHP-DI entries. This means **complete interoperability** between the 2 containers! For the record, PHP-DI entires can already reference Symfony's entries.

That's the solution if you need to use **tags** (e.g. voters, …) for a specific service -> you define it in Symfony (YAML) and you can still inject PHP-DI services into it.

For example:

```yaml
services:
    myservice:
        class: My\Service
        arguments: [ "@My\Other\Service" ]
        tags:
            -  { name: mailer.transport }
```

Here `My\Other\Service` is a service that PHP-DI will provide (not Symfony).

And the whole thing is even easier than before. Currently, what you have to do:

```php
class AppKernel extends Kernel
{
    // ...

    protected function getContainerBaseClass()
    {
        return 'DI\Bridge\Symfony\SymfonyContainerBridge';
    }

    protected function initializeContainer()
    {
        parent::initializeContainer();

        $builder = new \DI\ContainerBuilder();
        $builder->wrapContainer($this->getContainer());

        // Configure your container here
        $builder->addDefinitions(__DIR__ . '/config/config.php');

        $this->getContainer()->setFallbackContainer($builder->build());
    }
}
```

Now with this branch, you only do this:

```php
class AppKernel extends \DI\Bridge\Symfony\Kernel
{
    // ...

    protected function buildPHPDIContainer(ContainerBuilder $builder)
    {
        // Configure your container here
        $builder->addDefinitions(__DIR__ . '/config/config.php');

        return $builder->build();
    }
}
```

---

### Warnings

- I had to remove the `CheckExceptionOnInvalidReferenceBehaviorPass` compiler pass.

It checked for unknown references, and since it doesn't know about PHP-DI's entries, they are "unknown references" to it, so it throws exceptions.

I tried to replace it with a custom compiler pass (that would look into PHP-DI too), but PHP-DI is not built yet when Symfony's container is being compiled, so it doesn't seem really possible.

So is that really bad to have removed that compiler pass? Is that worth it? To be discussed.

- The user now has to extend our custom `Kernel` class instead of Symfony's one. I don't see that as a problem, is it?

- This branch breaks BC -> needs a major version bump

- The docs need to be updated

Feedback more than welcome, ping @tentacode