### PR TITLE
Fixed missing interface

### DIFF
--- a/src/DI/Bridge/Symfony/SymfonyContainerBridge.php
+++ b/src/DI/Bridge/Symfony/SymfonyContainerBridge.php
@@ -9,12 +9,12 @@
 
 namespace DI\Bridge\Symfony;
 
-use DI\ContainerInterface;
 use DI\NotFoundException;
 use Symfony\Component\DependencyInjection\Container as SymfonyContainer;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Interop\Container\ContainerInterface;
 
 /**
  * Replacement for the Symfony service container.

--- a/tests/UnitTest/DI/Bridge/Symfony/SymfonyContainerBridgeTest.php
+++ b/tests/UnitTest/DI/Bridge/Symfony/SymfonyContainerBridgeTest.php
@@ -19,7 +19,7 @@ class SymfonyContainerBridgeTest extends \PHPUnit_Framework_TestCase
     {
         $wrapper = new SymfonyContainerBridge();
 
-        $fallback = $this->getMockForAbstractClass('DI\ContainerInterface');
+        $fallback = $this->getMockForAbstractClass('Interop\Container\ContainerInterface');
         $fallback->expects($this->once())
             ->method('has')
             ->with('foo')
@@ -34,7 +34,7 @@ class SymfonyContainerBridgeTest extends \PHPUnit_Framework_TestCase
     {
         $wrapper = new SymfonyContainerBridge();
 
-        $fallback = $this->getMockForAbstractClass('DI\ContainerInterface');
+        $fallback = $this->getMockForAbstractClass('Interop\Container\ContainerInterface');
         $fallback->expects($this->once())
             ->method('get')
             ->with('foo')


### PR DESCRIPTION
Fixed missing DI\ContainerInterface in version 5 this interface is not exists, used Interop\Container\ContainerInterface instead which implements same logic.