### PR TITLE
Allow usage with php-di 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Build Status](https://travis-ci.org/PHP-DI/Symfony2-Bridge.png?branch=master)](https://travis-ci.org/PHP-DI/Symfony2-Bridge)
 
-This package provides integration for PHP-DI 4 with Symfony 2.
+This package provides integration for PHP-DI with Symfony 2.
 
 [PHP-DI](http://php-di.org) is a Dependency Injection Container for PHP.
 
-This package is compatible with **PHP-DI 4.x**.
+This package is compatible with PHP-DI **4.x** and **5.x**.
 
 **The documentation is here: http://php-di.org/doc/frameworks/symfony2.html**
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     },
     "require": {
-        "php-di/php-di": "~4.0",
+        "php-di/php-di": "~4.0 || ^5.0",
         "symfony/dependency-injection": "~2.0"
     }
 }


### PR DESCRIPTION
Since `\DI\Container` class in php-di 4 and php-di 5 implements `\Interop\Container\ContainerInterface`, I don't see any problems to allow symfony2-bridge usage with php-di 5.

The only problem was with dependency set-up: you could not install php-di 5 and this package together. This PR fixes problem.

For now I'm using php-di 5 and symfony 2.7 using my fork with this commit, everything works fine.
