### PR TITLE
PSR-11 friendly kernels

### DIFF
--- a/src/KernelWithPhpDiContainer.php
+++ b/src/KernelWithPhpDiContainer.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-abstract class Kernel extends \Symfony\Component\HttpKernel\Kernel
+abstract class KernelWithPhpDiContainer extends \Symfony\Component\HttpKernel\Kernel
 {
     /**
      * @var ContainerInterface

--- a/src/KernelWithPsr11Container.php
+++ b/src/KernelWithPsr11Container.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Bridge\Symfony;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Debug\DebugClassLoader;
+use Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Customization of Symfony's kernel to setup any PSR-11 container.
+ *
+ * Extend this class instead of Symfony's base kernel.
+ *
+ * @author Julien Janvier <j.janvier@gmail.com>
+ */
+abstract class KernelWithPsr11Container extends \Symfony\Component\HttpKernel\Kernel
+{
+    public function __construct($environment, $debug)
+    {
+        parent::__construct($environment, $debug);
+        $this->disableDebugClassLoader();
+    }
+
+    protected function getContainerBaseClass()
+    {
+        return SymfonyContainerBridge::class;
+    }
+
+    protected function buildContainer()
+    {
+        $containerBuilder = parent::buildContainer();
+
+        $this->removeInvalidReferenceBehaviorPass($containerBuilder);
+
+        return $containerBuilder;
+    }
+
+    protected function initializeContainer()
+    {
+        parent::initializeContainer();
+
+        /** @var SymfonyContainerBridge $rootContainer */
+        $rootContainer = $this->getContainer();
+
+        $rootContainer->setFallbackContainer($this->getFallbackContainer());
+    }
+
+    /**
+     * Remove the CheckExceptionOnInvalidReferenceBehaviorPass because
+     * it was not looking into PHP-DI's entries and thus throwing exceptions.
+     *
+     * @todo Replace it by an alternative that can search into PHP-DI too
+     *       Problem: PHP-DI is not initialized when Symfony's container is compiled, because
+     *       it depends on Symfony's container for fallback (cycle…)
+     *
+     * @param ContainerBuilder $container
+     */
+    private function removeInvalidReferenceBehaviorPass(ContainerBuilder $container)
+    {
+        $passConfig = $container->getCompilerPassConfig();
+        $compilationPasses = $passConfig->getRemovingPasses();
+
+        foreach ($compilationPasses as $i => $pass) {
+            if ($pass instanceof CheckExceptionOnInvalidReferenceBehaviorPass) {
+                unset($compilationPasses[$i]);
+                break;
+            }
+        }
+
+        $passConfig->setRemovingPasses($compilationPasses);
+    }
+
+    private function disableDebugClassLoader()
+    {
+        if (!class_exists(DebugClassLoader::class)) {
+            return;
+        }
+
+        DebugClassLoader::disable();
+    }
+
+    /**
+     * @return ContainerInterface
+     */
+    abstract protected function getFallbackContainer();
+}

--- a/src/SymfonyContainerBridge.php
+++ b/src/SymfonyContainerBridge.php
@@ -9,6 +9,7 @@
 
 namespace DI\Bridge\Symfony;
 
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Symfony\Component\DependencyInjection\Container as SymfonyContainer;
@@ -89,6 +90,8 @@ class SymfonyContainerBridge extends SymfonyContainer implements SymfonyContaine
             if ($invalidBehavior === self::EXCEPTION_ON_INVALID_REFERENCE) {
                 throw new ServiceNotFoundException($id, null, $e);
             }
+        } catch (ContainerExceptionInterface $e) {
+            throw new \Exception('Error while retrieving the entry.', $e->getCode(), $e);
         }
 
         return null;

--- a/src/SymfonyContainerBridge.php
+++ b/src/SymfonyContainerBridge.php
@@ -9,8 +9,8 @@
 
 namespace DI\Bridge\Symfony;
 
-use DI\NotFoundException;
 use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Symfony\Component\DependencyInjection\Container as SymfonyContainer;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
@@ -85,7 +85,7 @@ class SymfonyContainerBridge extends SymfonyContainer implements SymfonyContaine
             }
 
             return $entry;
-        } catch (NotFoundException $e) {
+        } catch (NotFoundExceptionInterface $e) {
             if ($invalidBehavior === self::EXCEPTION_ON_INVALID_REFERENCE) {
                 throw new ServiceNotFoundException($id, null, $e);
             }

--- a/tests/FunctionalTest/Fixtures/AppKernel.php
+++ b/tests/FunctionalTest/Fixtures/AppKernel.php
@@ -2,11 +2,11 @@
 
 namespace DI\Bridge\Symfony\Test\FunctionalTest\Fixtures;
 
-use DI\Bridge\Symfony\Kernel;
+use DI\Bridge\Symfony\KernelWithPhpDiContainer;
 use DI\ContainerBuilder;
 use Symfony\Component\Config\Loader\LoaderInterface;
 
-class AppKernel extends Kernel
+class AppKernel extends KernelWithPhpDiContainer
 {
     private $configFile;
 

--- a/tests/FunctionalTest/KernelWithPhpDiContainerTest.php
+++ b/tests/FunctionalTest/KernelWithPhpDiContainerTest.php
@@ -16,7 +16,7 @@ use DI\Bridge\Symfony\Test\FunctionalTest\Fixtures\Class2;
 /**
  * @coversNothing
  */
-class KernelTest extends AbstractFunctionalTest
+class KernelWithPhpDiContainerTest extends AbstractFunctionalTest
 {
     /**
      * @test


### PR DESCRIPTION
Hello Matthieu,

I'm not sure you'll be interested by this PR, but let's try. I was looking for something able to make me use a PSR-11 container with Symfony's kernel. And I found your bridge.

But I'd like to be able to use any kind of PSR-11 container. Hence this PR where you now have "PSR 11 compatible kernel" and specific "PHP DI compatible kernel".

If you're not interested just let me know. I'll create another bridge and refer to yours for the paternity.

What's missing:
- test the catch of `ContainerExceptionInterface` (but I suck in PHPUnit, I'm too used to PhpSpec sadly...) 
- test the `KernelWithPsr11Container`?